### PR TITLE
print xml's body before changing the product_code

### DIFF
--- a/uc/uc.py
+++ b/uc/uc.py
@@ -20,6 +20,7 @@ class VersionPlugin(MessagePlugin):
         company_report = body[0]
         company_report.set('ns1:product', self.product_code)
         company_report.set('ns1:version', '2.1')
+        print(context.envelope.getChild('Body'))
 
 
 def get_customer(client):

--- a/uc/uc.py
+++ b/uc/uc.py
@@ -1,7 +1,12 @@
+import logging
+
 from django.conf import settings
 
 from suds.client import Client
 from suds.plugin import MessagePlugin
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_client(product_code):
@@ -20,7 +25,7 @@ class VersionPlugin(MessagePlugin):
         company_report = body[0]
         company_report.set('ns1:product', self.product_code)
         company_report.set('ns1:version', '2.1')
-        print(context.envelope.getChild('Body'))
+        logger.debug(context.envelope.getChild('Body'))
 
 
 def get_customer(client):


### PR DESCRIPTION
This should allow us to see the xml request body when generating reports (using `heroku logs`).