### PR TITLE
use log.warning so we can also see the request xml body on prod

### DIFF
--- a/uc/uc.py
+++ b/uc/uc.py
@@ -25,7 +25,7 @@ class VersionPlugin(MessagePlugin):
         company_report = body[0]
         company_report.set('ns1:product', self.product_code)
         company_report.set('ns1:version', '2.1')
-        logger.debug(context.envelope.getChild('Body'))
+        logger.warning(context.envelope.getChild('Body'))
 
 
 def get_customer(client):


### PR DESCRIPTION
on production we have log level set to warning, so we can't see the xml body there, this solves it by logging a warning instead.