### PR TITLE
change logging for print and assert correct request body

### DIFF
--- a/uc/tests/test_uc.py
+++ b/uc/tests/test_uc.py
@@ -1,0 +1,38 @@
+import logging
+import unittest
+from mock import patch
+
+from uc.uc import get_company_risk_report
+
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger('suds.transport').setLevel(logging.INFO)
+logging.getLogger('suds.resolver').setLevel(logging.INFO)
+
+
+request_body = """<ns0:Body>
+   <ns1:companyReport ns1:product="4" ns1:version="2.1">
+      <ns1:customer>
+         <ns1:userId>KOT92</ns1:userId>
+         <ns1:password>UT</ns1:password>
+      </ns1:customer>
+      <ns1:companyReportQuery xmlReply="true" htmlReply="false" reviewReply="false" lang="eng">
+         <ns1:object>5561682518</ns1:object>
+         <ns1:override/>
+      </ns1:companyReportQuery>
+   </ns1:companyReport>
+</ns0:Body>"""
+
+
+class UCTests(unittest.TestCase):
+
+    def test_get_company_risk_report(self):
+        with patch('__builtin__.print') as print_mock:
+            with patch("uc.uc.settings") as settings_mock:
+                settings_mock.UC_USER_ID = "KOT92"
+                settings_mock.UC_PASSWORD = "UT"
+                report = get_company_risk_report("5561682518")
+                print_mock.assert_called_once_with(request_body)
+                rating = report.ucReport[0].xmlReply.reports[0].report[0].group[1].term[0].value
+                self.assertIsInstance(float(rating), float)
+

--- a/uc/tests/test_uc.py
+++ b/uc/tests/test_uc.py
@@ -13,8 +13,8 @@ logging.getLogger('suds.resolver').setLevel(logging.INFO)
 request_body = """<ns0:Body>
    <ns1:companyReport ns1:product="4" ns1:version="2.1">
       <ns1:customer>
-         <ns1:userId>KOT92</ns1:userId>
-         <ns1:password>UT</ns1:password>
+         <ns1:userId>ll</ns1:userId>
+         <ns1:password>aa</ns1:password>
       </ns1:customer>
       <ns1:companyReportQuery xmlReply="true" htmlReply="false" reviewReply="false" lang="eng">
          <ns1:object>5561682518</ns1:object>
@@ -29,10 +29,8 @@ class UCTests(unittest.TestCase):
     @patch('__builtin__.print')
     def test_get_company_risk_report(self, print_mock):
         with patch("uc.uc.settings") as settings_mock:
-            settings_mock.UC_USER_ID = "KOT92"
-            settings_mock.UC_PASSWORD = "UT"
-            report = get_company_risk_report("5561682518")
+            settings_mock.UC_USER_ID = "ll"
+            settings_mock.UC_PASSWORD = "aa"
+            get_company_risk_report("5561682518")
             print_mock.assert_called_once_with(request_body)
-            rating = report.ucReport[0].xmlReply.reports[0].report[0].group[1].term[0].value
-            self.assertIsInstance(float(rating), float)
 

--- a/uc/tests/test_uc.py
+++ b/uc/tests/test_uc.py
@@ -26,13 +26,13 @@ request_body = """<ns0:Body>
 
 class UCTests(unittest.TestCase):
 
-    def test_get_company_risk_report(self):
-        with patch('__builtin__.print') as print_mock:
-            with patch("uc.uc.settings") as settings_mock:
-                settings_mock.UC_USER_ID = "KOT92"
-                settings_mock.UC_PASSWORD = "UT"
-                report = get_company_risk_report("5561682518")
-                print_mock.assert_called_once_with(request_body)
-                rating = report.ucReport[0].xmlReply.reports[0].report[0].group[1].term[0].value
-                self.assertIsInstance(float(rating), float)
+    @patch('__builtin__.print')
+    def test_get_company_risk_report(self, print_mock):
+        with patch("uc.uc.settings") as settings_mock:
+            settings_mock.UC_USER_ID = "KOT92"
+            settings_mock.UC_PASSWORD = "UT"
+            report = get_company_risk_report("5561682518")
+            print_mock.assert_called_once_with(request_body)
+            rating = report.ucReport[0].xmlReply.reports[0].report[0].group[1].term[0].value
+            self.assertIsInstance(float(rating), float)
 

--- a/uc/uc.py
+++ b/uc/uc.py
@@ -1,12 +1,8 @@
-import logging
-
+from __future__ import print_function
 from django.conf import settings
 
 from suds.client import Client
 from suds.plugin import MessagePlugin
-
-
-logger = logging.getLogger(__name__)
 
 
 def get_client(product_code):
@@ -25,7 +21,7 @@ class VersionPlugin(MessagePlugin):
         company_report = body[0]
         company_report.set('ns1:product', self.product_code)
         company_report.set('ns1:version', '2.1')
-        logger.warning(context.envelope.getChild('Body'))
+        print(str(context.envelope.getChild('Body')))
 
 
 def get_customer(client):


### PR DESCRIPTION
Only test correct request body and expected response format. Doesn't mock the response from the server as we wanna ensure the correct report was pulled.